### PR TITLE
Demonstrate workaround (no need to merge)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-openfeign-core</artifactId>
+				<version>2.2.5.RELEASE.OGL</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-openfeign-core</artifactId>
-				<version>2.2.5.RELEASE.OGL</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/src/main/java/com/example/matrixdemo/ClientController.java
+++ b/src/main/java/com/example/matrixdemo/ClientController.java
@@ -34,7 +34,8 @@ public class ClientController {
     @GetMapping("/client/internalMatrixParams")
     public void internalMatrixParams() {
 
-        feignInternalServer.matrixParams("a", "n");
+//        feignInternalServer.matrixParams("a", "n");
+        throw new UnsupportedOperationException("can only pass matrix params as a map, not individually");
 
     }
 
@@ -51,9 +52,10 @@ public class ClientController {
 
 
     @GetMapping("/client/wiremockMatrixParams")
-    public void wiremocklMatrixParams() {
+    public void wiremockMatrixParams() {
 
-        feignWireMockServer.matrixParams("a", "n");
+//        feignWireMockServer.matrixParams("a", "n");
+        throw new UnsupportedOperationException("can only pass matrix params as a map, not individually");
 
     }
 

--- a/src/main/java/com/example/matrixdemo/FeignInternalServer.java
+++ b/src/main/java/com/example/matrixdemo/FeignInternalServer.java
@@ -14,7 +14,7 @@ public interface FeignInternalServer {
     @GetMapping("/server/matrixParamsMap{matrixVars}")
     void matrixParamsMap(@MatrixVariable Map<String, List<String>> matrixVars);
 
-    @GetMapping("/server/matrixParams{account}{name}")
-    void matrixParams(@MatrixVariable("account") String account, @MatrixVariable("name") String name);
+//    @GetMapping("/server/matrixParams{account}{name}")
+//    void matrixParams(@MatrixVariable("account") String account, @MatrixVariable("name") String name);
 
 }

--- a/src/main/java/com/example/matrixdemo/FeignWireMockServer.java
+++ b/src/main/java/com/example/matrixdemo/FeignWireMockServer.java
@@ -1,5 +1,6 @@
 package com.example.matrixdemo;
 
+import com.example.matrixdemo.config.MatrixEncodingFeignConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.MatrixVariable;
@@ -8,13 +9,13 @@ import java.util.List;
 import java.util.Map;
 
 
-@FeignClient(url = "http://localhost:7000", name = "wiremock")
+@FeignClient(url = "http://localhost:7000", name = "wiremock", configuration = MatrixEncodingFeignConfiguration.class)
 public interface FeignWireMockServer {
 
     @GetMapping("/server/matrixParamsMap{matrixVars}")
     void matrixParamsMap(@MatrixVariable Map<String, List<String>> matrixVars);
 
-    @GetMapping("/server/matrixParams{account}{name}")
-    void matrixParams(@MatrixVariable("account") String account, @MatrixVariable("name") String name);
+//    @GetMapping("/server/matrixParams{account}{name}")
+//    void matrixParams(@MatrixVariable("account") String account, @MatrixVariable("name") String name);
 
 }

--- a/src/main/java/com/example/matrixdemo/config/MatrixEncodingFeignConfiguration.java
+++ b/src/main/java/com/example/matrixdemo/config/MatrixEncodingFeignConfiguration.java
@@ -8,11 +8,21 @@
  */
 package com.example.matrixdemo.config;
 
+import feign.Contract;
 import feign.codec.Encoder;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.web.bind.annotation.MatrixVariable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -26,6 +36,28 @@ public class MatrixEncodingFeignConfiguration {
     public Encoder encoder(ObjectFactory<HttpMessageConverters> messageConverters) {
 
         return new MatrixVariableHandlingEncoder(messageConverters);
+    }
+
+
+    @Bean
+    public Contract feignContract(ConversionService feignConversionService,
+                                  List<AnnotatedParameterProcessor> parameterProcessors) {
+        SpringMvcContract contract =  new SpringMvcContract(parameterProcessors, feignConversionService);
+
+        try {
+            Field annotatedArgumentProcessorsField = SpringMvcContract.class.
+                    getDeclaredField("annotatedArgumentProcessors");
+            annotatedArgumentProcessorsField.setAccessible(true);
+            Map<Class<? extends Annotation>, AnnotatedParameterProcessor> annotatedArgumentProcessors =
+                    (Map) annotatedArgumentProcessorsField.get(contract);
+
+            annotatedArgumentProcessors.remove(MatrixVariable.class);
+
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        return contract;
     }
 
 }

--- a/src/main/java/com/example/matrixdemo/config/MatrixEncodingFeignConfiguration.java
+++ b/src/main/java/com/example/matrixdemo/config/MatrixEncodingFeignConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Dalet - All Rights Reserved
+ *
+ * This file is part of Ooyala Flex.
+ *
+ * Unauthorized copying and/or distribution of this file or any other part of Ooyala Flex, via any medium,
+ * is strictly prohibited.  Proprietary and confidential.
+ */
+package com.example.matrixdemo.config;
+
+import feign.codec.Encoder;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * As per https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-feign.html#spring-cloud-feign-overriding-defaults,
+ * this class does not need to be annotated with {@link Configuration}; and in fact doing so would require ComponentScan
+ * exclusions which it would be nicer to avoid.
+ */
+public class MatrixEncodingFeignConfiguration {
+
+    @Bean
+    public Encoder encoder(ObjectFactory<HttpMessageConverters> messageConverters) {
+
+        return new MatrixVariableHandlingEncoder(messageConverters);
+    }
+
+}

--- a/src/main/java/com/example/matrixdemo/config/MatrixVariableHandlingEncoder.java
+++ b/src/main/java/com/example/matrixdemo/config/MatrixVariableHandlingEncoder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Dalet - All Rights Reserved
+ *
+ * This file is part of Ooyala Flex.
+ *
+ * Unauthorized copying and/or distribution of this file or any other part of Ooyala Flex, via any medium,
+ * is strictly prohibited.  Proprietary and confidential.
+ */
+package com.example.matrixdemo.config;
+
+import feign.RequestTemplate;
+import feign.form.spring.SpringFormEncoder;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * The Encoder implementation will use to add matrix params in request.
+ */
+public class MatrixVariableHandlingEncoder extends SpringEncoder {
+
+    public MatrixVariableHandlingEncoder(ObjectFactory<HttpMessageConverters> messageConverters) {
+
+        super(messageConverters);
+
+        System.out.println("OGL: CREATING ENCODER");
+    }
+
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void encode(Object object, Type type, RequestTemplate template) {
+
+        System.out.println("OGL: running encode on " + object);
+        if (object instanceof Map) {
+            Map<String, List<String>> matrixParams = (Map) object;
+
+            StringBuilder builder = new StringBuilder();
+            if (!matrixParams.isEmpty()) {
+                for (Map.Entry<String, List<String>> entry : matrixParams.entrySet()) {
+                    entry.getValue().forEach(value -> builder.append(";").append(entry.getKey()).append("=")
+                            .append(value));
+                }
+            }
+            System.out.println("OGL: running encode on " + builder.toString());
+            template.uri(StringUtils.isNotEmpty(builder.toString()) ? builder.substring(0) : "", true);
+
+        }
+        else if (object instanceof MultipartFile) {
+            new SpringFormEncoder().encode(object, type, template);
+        }
+        else {
+            super.encode(object, type, template);
+        }
+
+    }
+
+}

--- a/src/test/java/com/ooyala/matrixdemo/FeignDemoTest.java
+++ b/src/test/java/com/ooyala/matrixdemo/FeignDemoTest.java
@@ -25,8 +25,12 @@ public class FeignDemoTest {
     @Before
     public void setUp() {
 
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/server/matrixParams;account=a;name=n"))
-                                 .willReturn(aResponse().withStatus(200)));
+//        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/server/matrixParams;account=a;name=n"))
+//                .willReturn(aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/server/matrixParamsMap;account=a;name=n"))
+                .willReturn(aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/server/matrixParamsMap;name=n;account=a"))
+                .willReturn(aResponse().withStatus(200)));
     }
 
 
@@ -38,12 +42,12 @@ public class FeignDemoTest {
     }
 
 
-    @Test
-    public void internalMatrixParams() throws IOException {
-
-        runTest("http://localhost:8080/client/internalMatrixParams");
-
-    }
+//    @Test
+//    public void internalMatrixParams() throws IOException {
+//
+//        runTest("http://localhost:8080/client/internalMatrixParams");
+//
+//    }
 
 
     @Test
@@ -54,12 +58,12 @@ public class FeignDemoTest {
     }
 
 
-    @Test
-    public void wiremockMatrixParams() throws IOException {
-
-        runTest("http://localhost:8080/client/wiremockMatrixParams");
-
-    }
+//    @Test
+//    public void wiremockMatrixParams() throws IOException {
+//
+//        runTest("http://localhost:8080/client/wiremockMatrixParams");
+//
+//    }
 
 
     private void runTest(String url) throws IOException {


### PR DESCRIPTION
This PR demonstrates a workaround for issue https://github.com/spring-cloud/spring-cloud-openfeign/issues/395 and https://github.com/OpenFeign/feign/issues/1319, which thus far have had little traction with being fixed by the Spring Cloud / OpenFeign maintainers.

It makes use of a custom encoder approach along the lines of those discussed in https://github.com/spring-cloud/spring-cloud-openfeign/issues/117 prior to Spring-Cloud's introduction of the `MatrixVariableProcessor`.

It then overrides configuration in order to remove the existence of the MatrixVariableProcessor, allowing the custom encoder to work as it previously did.

It's not beautiful, but it does the job.  Note that the specification of individual matrix params is not supported (just as it wasn't before the introduction of the `MatrixVariableProcessor`.